### PR TITLE
Add support for not reporting empty test assemblies

### DIFF
--- a/GitHubActionsTestLogger.Tests/SummarySpecs.cs
+++ b/GitHubActionsTestLogger.Tests/SummarySpecs.cs
@@ -184,4 +184,46 @@ public class SummarySpecs(ITestOutputHelper testOutput)
 
         testOutput.WriteLine(output);
     }
+
+    [Fact]
+    public void I_can_use_the_logger_to_produce_a_summary_that_reports_empty_test_assemblies()
+    {
+        // Arrange
+        using var summaryWriter = new StringWriter();
+
+        var context = new TestLoggerContext(
+            new GitHubWorkflow(TextWriter.Null, summaryWriter),
+            TestLoggerOptions.Default
+        );
+
+        // Act
+        context.SimulateTestRun();
+
+        // Assert
+        var output = summaryWriter.ToString().Trim();
+        output.Should().Contain("⚪️ FakeTests");
+
+        testOutput.WriteLine(output);
+    }
+
+    [Fact]
+    public void I_can_use_the_logger_to_produce_no_summary_for_empty_test_assemblies_using_options()
+    {
+        // Arrange
+        using var summaryWriter = new StringWriter();
+
+        var context = new TestLoggerContext(
+            new GitHubWorkflow(TextWriter.Null, summaryWriter),
+            new TestLoggerOptions { SummaryIncludeNotFoundTests = false }
+        );
+
+        // Act
+        context.SimulateTestRun();
+
+        // Assert
+        var output = summaryWriter.ToString().Trim();
+        output.Should().BeNullOrEmpty();
+
+        testOutput.WriteLine(output);
+    }
 }

--- a/GitHubActionsTestLogger/TestLoggerContext.cs
+++ b/GitHubActionsTestLogger/TestLoggerContext.cs
@@ -133,6 +133,12 @@ public class TestLoggerContext(GitHubWorkflow github, TestLoggerOptions options)
                 TestResults = testResults
             };
 
+            if (
+                !Options.SummaryIncludeNotFoundTests
+                && testRunStatistics.OverallOutcome == TestOutcome.NotFound
+            )
+                return;
+
             github.CreateSummary(template.Render());
         }
     }

--- a/GitHubActionsTestLogger/TestLoggerOptions.cs
+++ b/GitHubActionsTestLogger/TestLoggerOptions.cs
@@ -12,6 +12,8 @@ public partial class TestLoggerOptions
     public bool SummaryIncludePassedTests { get; init; }
 
     public bool SummaryIncludeSkippedTests { get; init; }
+
+    public bool SummaryIncludeNotFoundTests { get; init; } = true;
 }
 
 public partial class TestLoggerOptions
@@ -33,5 +35,8 @@ public partial class TestLoggerOptions
             SummaryIncludeSkippedTests =
                 parameters.GetValueOrDefault("summary.includeSkippedTests")?.Pipe(bool.Parse)
                 ?? Default.SummaryIncludeSkippedTests,
+            SummaryIncludeNotFoundTests =
+                parameters.GetValueOrDefault("summary.includeNotFoundTests")?.Pipe(bool.Parse)
+                ?? Default.SummaryIncludeSkippedTests
         };
 }

--- a/GitHubActionsTestLogger/TestRunStatistics.cs
+++ b/GitHubActionsTestLogger/TestRunStatistics.cs
@@ -24,6 +24,9 @@ internal record TestRunStatistics(
             if (SkippedTestCount > 0)
                 return TestOutcome.Skipped;
 
+            if (TotalTestCount == 0)
+                return TestOutcome.NotFound;
+
             return TestOutcome.None;
         }
     }

--- a/GitHubActionsTestLogger/TestSummaryTemplate.cshtml
+++ b/GitHubActionsTestLogger/TestSummaryTemplate.cshtml
@@ -23,6 +23,7 @@
         {
             TestOutcome.Passed => "🟢",
             TestOutcome.Failed => "🔴",
+            TestOutcome.NotFound => "⚪️",
             _ => "🟡"
         };
     }

--- a/Readme.md
+++ b/Readme.md
@@ -206,6 +206,3 @@ not yielding **any** tests. This might be done on purpose in which case reportin
 The default behavior is to include test assemblies without any tests in the report.
 
 **Default**: `true`.
-
-> **Warning**:
-> If your test suite is really large, enabling this option may cause the summary to exceed the [maximum allowed size](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#step-isolation-and-limits).

--- a/Readme.md
+++ b/Readme.md
@@ -196,11 +196,12 @@ If you want to link skipped tests to their corresponding source definitions, mak
 > **Warning**:
 > If your test suite is really large, enabling this option may cause the summary to exceed the [maximum allowed size](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#step-isolation-and-limits).
 > 
+
 #### Include not found tests in summary
 
-Use the `summary.includeNotFoundTests` option to specify whether test assemblies that did not yield any tests to run should be included.
+Use the `summary.includeNotFoundTests` option to specify whether test assemblies that did not yield any runnable tests should be included in the summary.
 
-Using [test filters](https://learn.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests?pivots=mstest) might result in some test assemblies
+Using [test filters](https://learn.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests) might result in some test assemblies
 not yielding **any** tests. This might be done on purpose in which case reporting these may not be helpful. 
 
 The default behavior is to include test assemblies without any tests in the report.

--- a/Readme.md
+++ b/Readme.md
@@ -195,3 +195,17 @@ If you want to link skipped tests to their corresponding source definitions, mak
 
 > **Warning**:
 > If your test suite is really large, enabling this option may cause the summary to exceed the [maximum allowed size](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#step-isolation-and-limits).
+> 
+#### Include not found tests in summary
+
+Use the `summary.includeNotFoundTests` option to specify whether test assemblies that did not yield any tests to run should be included.
+
+Using [test filters](https://learn.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests?pivots=mstest) might result in some test assemblies
+not yielding **any** tests. This might be done on purpose in which case reporting these may not be helpful. 
+
+The default behavior is to include test assemblies without any tests in the report.
+
+**Default**: `true`.
+
+> **Warning**:
+> If your test suite is really large, enabling this option may cause the summary to exceed the [maximum allowed size](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#step-isolation-and-limits).


### PR DESCRIPTION
We use `--filter` to selectively run test assemblies in different runs. 

This produces somewhat noisy reports where assemblies are marked as (failed/succeeded) and skipped multiple times:

https://github.com/elastic/apm-agent-dotnet/actions/runs/9275127823?pr=2315#summary-25519083669

This PR now differentiates assemblies with no tests from assemblies with skipped tests using ⚪️. It also introduces an option to not report test assemblies without any tests (defaults still is to so).