### PR TITLE
Fix incorrect fallback for the "include not found tests" option

### DIFF
--- a/GitHubActionsTestLogger.Tests/InitializationSpecs.cs
+++ b/GitHubActionsTestLogger.Tests/InitializationSpecs.cs
@@ -24,7 +24,7 @@ public class InitializationSpecs
     }
 
     [Fact]
-    public void I_can_use_the_logger_with_empty_configuration()
+    public void I_can_use_the_logger_with_an_empty_configuration()
     {
         // Arrange
         var logger = new TestLogger();

--- a/GitHubActionsTestLogger.Tests/InitializationSpecs.cs
+++ b/GitHubActionsTestLogger.Tests/InitializationSpecs.cs
@@ -20,7 +20,22 @@ public class InitializationSpecs
 
         // Assert
         logger.Context.Should().NotBeNull();
-        logger.Context?.Options.Should().Be(TestLoggerOptions.Default);
+        logger.Context?.Options.Should().BeEquivalentTo(TestLoggerOptions.Default);
+    }
+
+    [Fact]
+    public void I_can_use_the_logger_with_empty_configuration()
+    {
+        // Arrange
+        var logger = new TestLogger();
+        var events = new FakeTestLoggerEvents();
+
+        // Act
+        logger.Initialize(events, new Dictionary<string, string?>());
+
+        // Assert
+        logger.Context.Should().NotBeNull();
+        logger.Context?.Options.Should().BeEquivalentTo(TestLoggerOptions.Default);
     }
 
     [Fact]
@@ -35,7 +50,8 @@ public class InitializationSpecs
             ["annotations.titleFormat"] = "TitleFormat",
             ["annotations.messageFormat"] = "MessageFormat",
             ["summary.includePassedTests"] = "true",
-            ["summary.includeSkippedTests"] = "true"
+            ["summary.includeSkippedTests"] = "true",
+            ["summary.includeNotFoundTests"] = "true"
         };
 
         // Act
@@ -47,5 +63,6 @@ public class InitializationSpecs
         logger.Context?.Options.AnnotationMessageFormat.Should().Be("MessageFormat");
         logger.Context?.Options.SummaryIncludePassedTests.Should().BeTrue();
         logger.Context?.Options.SummaryIncludeSkippedTests.Should().BeTrue();
+        logger.Context?.Options.SummaryIncludeNotFoundTests.Should().BeTrue();
     }
 }

--- a/GitHubActionsTestLogger/TestLoggerOptions.cs
+++ b/GitHubActionsTestLogger/TestLoggerOptions.cs
@@ -37,6 +37,6 @@ public partial class TestLoggerOptions
                 ?? Default.SummaryIncludeSkippedTests,
             SummaryIncludeNotFoundTests =
                 parameters.GetValueOrDefault("summary.includeNotFoundTests")?.Pipe(bool.Parse)
-                ?? Default.SummaryIncludeSkippedTests
+                ?? Default.SummaryIncludeNotFoundTests
         };
 }

--- a/GitHubActionsTestLogger/TestRunStatistics.cs
+++ b/GitHubActionsTestLogger/TestRunStatistics.cs
@@ -11,23 +11,13 @@ internal record TestRunStatistics(
     TimeSpan OverallDuration
 )
 {
-    public TestOutcome OverallOutcome
-    {
-        get
+    public TestOutcome OverallOutcome { get; } =
+        true switch
         {
-            if (FailedTestCount > 0)
-                return TestOutcome.Failed;
-
-            if (PassedTestCount > 0)
-                return TestOutcome.Passed;
-
-            if (SkippedTestCount > 0)
-                return TestOutcome.Skipped;
-
-            if (TotalTestCount == 0)
-                return TestOutcome.NotFound;
-
-            return TestOutcome.None;
-        }
-    }
+            _ when FailedTestCount > 0 => TestOutcome.Failed,
+            _ when PassedTestCount > 0 => TestOutcome.Passed,
+            _ when SkippedTestCount > 0 => TestOutcome.Skipped,
+            _ when TotalTestCount == 0 => TestOutcome.NotFound,
+            _ => TestOutcome.None
+        };
 }


### PR DESCRIPTION
Last PR (#26) had a typo which resolved the "include not found tests" option to an incorrect fallback when this specific option was not provided, but some others were. Unfortunately, it was not caught in review and there was no test for this edge case. This PR remedies that.