### PR TITLE
Pack props into buildTransitive so MTP registration flows to transitive consumers

### DIFF
--- a/GitHubActionsTestLogger/GitHubActionsTestLogger.csproj
+++ b/GitHubActionsTestLogger/GitHubActionsTestLogger.csproj
@@ -19,7 +19,11 @@
 
   <ItemGroup>
     <None Include="../favicon.png" Pack="true" PackagePath="" Visible="false" />
-    <Content Include="GitHubActionsTestLogger.props" Pack="true" PackagePath="build;buildTransitive" />
+    <Content
+      Include="GitHubActionsTestLogger.props"
+      Pack="true"
+      PackagePath="build;buildTransitive"
+    />
   </ItemGroup>
 
   <ItemGroup>

--- a/GitHubActionsTestLogger/GitHubActionsTestLogger.csproj
+++ b/GitHubActionsTestLogger/GitHubActionsTestLogger.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <None Include="../favicon.png" Pack="true" PackagePath="" Visible="false" />
-    <Content Include="GitHubActionsTestLogger.props" Pack="true" PackagePath="build" />
+    <Content Include="GitHubActionsTestLogger.props" Pack="true" PackagePath="build;buildTransitive" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Problem

In Microsoft.Testing.Platform mode, the extension registers itself through the `TestingPlatformBuilderHook` item declared in `GitHubActionsTestLogger.props`. That props file is packed only into `build/`, and NuGet imports `build/` assets **only for direct package references** — `buildTransitive/` is the folder that flows to transitive consumers.

So when the package is consumed transitively — e.g. an organization's shared testing package declares `GitHubActionsTestLogger` as a dependency so every test project gets it — the compile/runtime assets arrive fine, but the builder hook item never reaches the test project. The source-generated `SelfRegisteredExtensions` omits the extension and the reporter silently never runs.

## Fix

Pack the same props file into both folders:

```xml
<Content Include="GitHubActionsTestLogger.props" Pack="true" PackagePath="build;buildTransitive" />
```

VSTest usage is unaffected (the logger assembly already flows transitively to the build output where VSTest discovers it; the props only matter for MTP registration).

## Validation

Scenario: `Consumer` (xunit.v3.mtp-v2 test project) → references `TestKit` (packaged class library) → depends on `GitHubActionsTestLogger`. No direct reference from `Consumer`.

| Package | `GitHubActionsTestLogger.MtpIntegration.AddExtensions` in generated `SelfRegisteredExtensions.cs` |
|---|---|
| 3.0.4 (build/ only) | ❌ absent — extension never registers |
| this branch (build/ + buildTransitive/) | ✅ present |

Also verified the produced nupkg contains both `build/GitHubActionsTestLogger.props` and `buildTransitive/GitHubActionsTestLogger.props`.